### PR TITLE
Feature/filter

### DIFF
--- a/src/components/pages/Account.vue
+++ b/src/components/pages/Account.vue
@@ -10,25 +10,43 @@
                 <i class="fas fa-cog ml-2"></i>
             </div>
         </section>
-        <section class="note px-3">
+        <section class="note">
+            <div class="note-utilities">
+                <ul class="note-filter">
+                    <FilterItem 
+                        v-for="(value, key) in filters" 
+                        :key="key" 
+                        :filterType="value.type" 
+                        :filterActive="value.active"
+                        @click="onClickedFilterItem(key)"
+                    />
+                </ul>
+                <i class="fas fa-search note-search"></i>
+            </div>
             <DailyNote v-for="(value, key) in note" :key="key" :date="key" :memos="value"/>
         </section>
     </div>
 </template>
 
 <script lang="ts">
-import DailyNote from '@/components/parts/DailyNote.vue';
 import { Component, Vue } from 'vue-property-decorator';
 
+import DailyNote from '@/components/parts/DailyNote.vue';
+import FilterItem from '@/components/parts/FilterItem.vue';
+
 import appStore, { StatusLevel } from '@/store/modules/app';
+import filterStore from '@/store/modules/filter';
 import noteService from '@/services/note';
 import noteStore from '@/store/modules/note';
 import datelib from '@/lib/datelib';
 
-@Component({ components: { DailyNote } })
+@Component({ components: { DailyNote, FilterItem } })
 export default class AccountPage extends Vue {
     get note() {
-     return noteStore.dailyNote;
+        return noteStore.dailyNote;
+    }
+    get filters() {
+        return filterStore.filters;
     }
 
     created() {
@@ -42,7 +60,22 @@ export default class AccountPage extends Vue {
                 const level = StatusLevel.Warning;
                 const message = err;
                 appStore.setStatus({ level, message });
+            });
+    }
+
+    onClickedFilterItem(index: number): void {
+        filterStore.switch(index);
+        noteService.filter(filterStore.filters[index].type)
+            .then((result: any) => {
+                if (result.status === 'success') {
+                    noteStore.replaceList(result.data);
+                }
             })
+            .catch((err: string) => {
+                const level = StatusLevel.Warning;
+                const message = err;
+                appStore.setStatus({ level, message });
+            });
     }
 }
 </script>
@@ -53,6 +86,7 @@ section.profile {
     display: flex;
     justify-content: space-between;
     width: 100%;
+    margin-top: 1rem;
 }
 
 .profile-left {
@@ -63,6 +97,7 @@ section.profile {
 }
 .profile-left i.fa-user-circle {
     font-size: 3.125rem;
+    color: #ccc;
 }
 
 .profile-right {
@@ -80,5 +115,25 @@ section.note {
   max-width: 680px;
   margin-bottom: 1rem;
 }
+
+.note-utilities {
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
+    margin-top: 2rem;
+}
+
+.note-filter {
+    display: flex;
+    flex-direction: row;
+    list-style-type: none;
+    justify-content: flex-start;
+    padding: 0;
+}
+
+.note-filter li {
+    margin-right: 1rem;
+}
+
 </style>
 

--- a/src/components/parts/DailyNote.vue
+++ b/src/components/parts/DailyNote.vue
@@ -1,7 +1,7 @@
 <template>
     <div class="root">
         <div class="date text-muted mb-2">
-            {{ date }}
+            <span>{{ date }}</span>
         </div>
         <div class="pages">
             <Page class="mb-4" v-for="memo in memos" :key="memo.id" :id="memo.id" :memoObject="memo"/>
@@ -18,15 +18,13 @@ import { IMemoState } from '@/store/modules/note';
 @Component({ components: { Page } })
 export default class DialyNote extends Vue {
     @Prop({ type: String })
-    date: string
+    date: string;
 
     @Prop({ type: Array })
-    memos: IMemoState[]
+    memos: IMemoState[];
 
     constructor() {
         super();
-        this.date = '';
-        this.memos = [];
     }
 }
 </script>
@@ -34,7 +32,7 @@ export default class DialyNote extends Vue {
 <style scoped lang="scss">
 .date {
     display: flex;
-    flex-direction: row;
+    flex-direction: column;
     align-items: center;
 }
 </style>

--- a/src/components/parts/FilterItem.vue
+++ b/src/components/parts/FilterItem.vue
@@ -1,0 +1,47 @@
+<template>
+    <li v-if="label != null">
+        <span v-if="filterActive">{{ label }}</span>
+        <a v-else href="#" class="text-muted" @click="onClickFilterItem">{{ label }}</a>
+    </li>
+</template>
+
+<script lang="ts">
+import { Vue, Component, Prop, Emit } from 'vue-property-decorator';
+
+import { FilterType } from '@/store/modules/filter';
+
+@Component({})
+export default class FilterItem extends Vue {
+    @Prop()
+    filterType!: string;
+
+    @Prop()
+    filterActive!: boolean;
+
+    get label(): string | null {
+        switch(this.filterType) {
+            case FilterType.All:
+                return 'All';
+                break;
+            case FilterType.Public:
+                return 'Public';
+                break;
+            case FilterType.Private:
+                return 'Private';
+                break;
+            default:
+                return null;
+        }
+    }
+
+    @Emit()
+    private click(){
+    }
+
+    public onClickFilterItem() {
+        this.click();
+    }
+}
+</script>
+
+

--- a/src/services/note.ts
+++ b/src/services/note.ts
@@ -138,9 +138,52 @@ const remove = async (id: string): Promise<IIDResponse> => {
   });
 };
 
+// filter mock
+const filter = async (filterType: string): Promise<IListResponse> => {
+  switch (filterType) {
+    case "ALL":
+      return list();
+    case "PUBLIC":
+      return new Promise((resolve: (value?: IListResponse) => void, reject: (reason?: any) => void) => {
+        resolve({
+          status: 'success',
+          data: [
+            {
+              title: 'Public Memo',
+              body: 'Public Memo',
+              id: 'PUBLIC_MEMO',
+              createdAt: 0,
+              updatedAt: 0,
+            }
+          ],
+        });
+      });
+    case 'PRIVATE':
+      return new Promise((resolve: (value?: IListResponse) => void, reject: (reason?: any) => void) => {
+        resolve({
+          status: 'success',
+          data: [
+            {
+              title: 'Private Memo',
+              body: 'Private Memo',
+              id: 'PRIVATE_MEMO',
+              createdAt: 0,
+              updatedAt: 0,
+            }
+          ],
+        });
+      });
+    default:
+      return new Promise((resolve: (value?: IListResponse) => void, reject: (reason?: any) => void) => {
+        reject('unknown filter type');
+      });
+  }
+};
+
 export default {
   save,
   get,
   list,
   remove,
+  filter,
 };

--- a/src/store/modules/filter.test.ts
+++ b/src/store/modules/filter.test.ts
@@ -1,0 +1,16 @@
+import filterStore, { IFilter } from '@/store/modules/filter';
+
+test('test filter initialization', async () => {
+    expect(filterStore.filters[0].active).toBe(true);
+});
+
+test('test filter.switch', async() => {
+    filterStore.switch(1);
+    filterStore.filters.forEach((currentFilter: IFilter, currentIndex: number): void => {
+        if (currentIndex === 1) {
+            expect(currentFilter.active).toBe(true);
+        } else {
+            expect(currentFilter.active).toBe(false);
+        }
+    });
+});

--- a/src/store/modules/filter.ts
+++ b/src/store/modules/filter.ts
@@ -1,0 +1,45 @@
+import { Mutation, MutationAction, Action, VuexModule, getModule, Module } from 'vuex-module-decorators';
+import store from '@/store';
+
+export interface IFilterState {
+    filters: IFilter[];
+}
+
+export interface IFilter {
+    type: FilterType;
+    active: boolean;
+}
+
+export enum FilterType {
+    All = 'ALL',
+    Public = 'PUBLIC',
+    Private = 'PRIVATE',
+}
+
+@Module({ dynamic: true, store, name: 'filter', namespaced: true })
+class Filter extends VuexModule implements IFilterState {
+    public filters: IFilter[] = [
+        { type: FilterType.All, active: true },
+        { type: FilterType.Public, active: false},
+        { type: FilterType.Private, active: false},
+    ];
+    
+
+    @Action
+    public switch(index: number): void {
+        this.SWITCH(index);
+    }
+
+    @Mutation
+    private SWITCH(index: number): void {
+        this.filters.forEach((currentFilter: IFilter, currentIndex: number) => {
+            if (currentIndex === index) {
+                this.filters[currentIndex].active = true;
+            } else {
+                this.filters[currentIndex].active = false;
+            }
+        });
+    }
+}
+
+export default getModule(Filter);

--- a/src/store/modules/note.ts
+++ b/src/store/modules/note.ts
@@ -40,17 +40,17 @@ class Note extends VuexModule implements INoteState {
     }
 
     // actions
-    @Action({ commit: 'SAVE' })
-    public save(memo: IMemoState) {
-        return memo;
+    @Action
+    public save(memo: IMemoState): void {
+        this.SAVE(memo);
     }
-    @Action({ commit: 'REPLACE_LIST' })
-    public replaceList(memos: IMemoState[]) {
-        return memos;
+    @Action
+    public replaceList(memos: IMemoState[]): void {
+        this.REPLACE_LIST(memos);
     }
-    @Action({ commit: 'REMOVE' })
-    public remove(id: string) {
-        return id;
+    @Action
+    public remove(id: string): void {
+        this.REMOVE(id);
     }
 
     // mutation


### PR DESCRIPTION
## Issue
#21

## Change log
* serviceにフィルタ機能のmockを作成
* VuexにfilterというStoreを追加
  * アプリで使うフィルターの種類と、「有効になっているのはどのフィルターか」を管理
  * `filterStore.switch(index: number): void`で有効にするフィルターを切り替え
  * 実際のフィルタ処理（serviceの呼び出しとnoteStoreの更新）はpage側で行う
* FilterItemコンポネントを追加
  * フィルタの選択肢ごとに使われるコンポネント（いまのところAll/Public/Privateの3種類）
  * 実態はli要素
  * AccountPageから2つの情報をもらって、liの中身を切り分ける
    * そのフィルタが有効かどうか（active） -> liの中身をspanにするかaにするかを決定
    * フィルタの種類（type） -> 表示するlabelを決定
    
