### PR TITLE
Improve route baheviour relates to EditPage

### DIFF
--- a/src/components/globals/Navbar.vue
+++ b/src/components/globals/Navbar.vue
@@ -6,7 +6,7 @@
       </div>
       
       <div class="navbar-menu">
-        <router-link to="/edit">
+        <router-link to="/edit/new">
           <button type="button" class="icon-btn icon-btn-primary"><i class="fas fa-plus"></i></button>
         </router-link>
         <router-link to="/account" class="ml-1">

--- a/src/components/pages/AccountPage.vue
+++ b/src/components/pages/AccountPage.vue
@@ -6,8 +6,8 @@
                 <a class="ml-2">You</a>
             </div>
             <div class="profile-right">
-                <a>yourmail@your.com</a>
-                <i class="fas fa-cog ml-2"></i>
+                <router-link to="/setting" class="text-muted">yourmail@your.com</router-link>
+                <router-link to="/setting"><i class="fas fa-cog ml-2 text-muted"></i></router-link>
             </div>
         </section>
         <section class="note">

--- a/src/components/pages/HomePage.vue
+++ b/src/components/pages/HomePage.vue
@@ -1,3 +1,3 @@
 <template>
-    <p>Suzuri is minimal markdown note for flash memo. <router-link to="/edit">Go to Editor</router-link></p> 
+    <p>Suzuri is minimal markdown note for flash memo. <router-link to="/edit/new">Go to Editor</router-link></p> 
 </template>

--- a/src/router.ts
+++ b/src/router.ts
@@ -16,7 +16,7 @@ export default new Router({
       component: HomePage,
     },
     {
-      path: '/edit',
+      path: '/edit/:id',
       name: 'edit',
       component: EditPage,
     },


### PR DESCRIPTION
* `/edit/:id`というURL形式でEditPageにアクセスできるようにする
  * e.g. `/edit/VGxzwgSRK`
  * URLで渡されたidを使ってメモの内容を引き出し、編集できる
  * idが`new`の場合は新規作成
* `/edit/:id`から別の`/edit/:id`へと遷移したときにIDの変更を検知するために、Vue-Routerの`beforeRouteUpdate`ナビゲーションガードを使用
  * e.g. 既存のメモ編集中に新規作成ボタンを押したとき
  * `beforeRouteUpdate` についてはこちら：https://router.vuejs.org/guide/essentials/dynamic-matching.html#reacting-to-params-changes
  * vue-class-componentでこれを使えるようにするためにはカスタムフックの追加が必要だった。参照：https://github.com/vuejs/vue-class-component#adding-custom-hooks